### PR TITLE
report correct disk size when using local storage

### DIFF
--- a/lib/fog/proxmox/helpers/disk_helper.rb
+++ b/lib/fog/proxmox/helpers/disk_helper.rb
@@ -80,8 +80,22 @@ module Fog
         [storage, volid, size]
       end
 
+      def self.to_bytes(size)
+	val=size.match(/\d+(\w?)/)
+	case val[1] 
+	  when NIL then m=0
+	  when "K" then m=1
+	  when "M" then m=2
+	  when "G" then m=3
+	  when "T" then m=4
+          when "P" then m=5
+        end
+	val[0].to_i*1024**m
+      end
+
       def self.extract_size(disk_value)
-        extract_option('size', disk_value).to_i
+        size=extract_option('size', disk_value)
+	self.to_bytes(size)
       end
     end
   end

--- a/lib/fog/proxmox/helpers/disk_helper.rb
+++ b/lib/fog/proxmox/helpers/disk_helper.rb
@@ -81,16 +81,16 @@ module Fog
       end
 
       def self.to_bytes(size)
-	val=size.match(/\d+(\w?)/)
-	m=0
-	case val[1] 
-	  when "K" then m=1
-	  when "M" then m=2
-	  when "G" then m=3
-	  when "T" then m=4
+        val=size.match(/\d+(\w?)/)
+        m=0
+        case val[1] 
+          when "K" then m=1
+          when "M" then m=2
+          when "G" then m=3
+          when "T" then m=4
           when "P" then m=5
         end
-	val[0].to_i*1024**m
+        val[0].to_i*1024**m
       end
 
       def self.extract_size(disk_value)

--- a/lib/fog/proxmox/helpers/disk_helper.rb
+++ b/lib/fog/proxmox/helpers/disk_helper.rb
@@ -57,9 +57,10 @@ module Fog
       end
 
       def self.extract_storage_volid_size(disk_value)
+        #volid definition: <VOULME_ID>:=<STORAGE_ID>:<storage type dependent volume name>
         values_a = disk_value.scan(/^(([\w-]+)[:]{0,1}([\w\/\.-]+))/)
         no_cdrom = !disk_value.match(/^(.+)[,]{1}(media=cdrom)$/)
-        creation = disk_value.match(/^(([\w-]+)[:]{1}([\d]+))/)
+        creation = disk_value.split(',')[0].match(/^(([\w-]+)[:]{1}([\d]+))$/)
         values = values_a.first if values_a
         if no_cdrom
           if creation

--- a/lib/fog/proxmox/helpers/disk_helper.rb
+++ b/lib/fog/proxmox/helpers/disk_helper.rb
@@ -82,8 +82,8 @@ module Fog
 
       def self.to_bytes(size)
 	val=size.match(/\d+(\w?)/)
+	m=0
 	case val[1] 
-	  when NIL then m=0
 	  when "K" then m=1
 	  when "M" then m=2
 	  when "G" then m=3

--- a/spec/helpers/disk_helper_spec.rb
+++ b/spec/helpers/disk_helper_spec.rb
@@ -34,6 +34,14 @@ require 'fog/proxmox/helpers/disk_helper'
             { scsi0: 'local-lvm:vm-100-disk-1,size=8G,cache=none'}
         end
 
+        let(:virtio1) do
+	    { id: 'virtio1', volid: 'local:108/vm-108-disk-1.qcow2,size=15G' }
+	end
+
+	let(:virtio) do
+	    { virtio1: 'local:108/vm-108-disk-1.qcow2,size=15G' }
+	end
+
         let(:cdrom_none) do 
             { ide2: 'none,media=cdrom'}
         end
@@ -54,7 +62,11 @@ require 'fog/proxmox/helpers/disk_helper'
         end
 
         describe '#extract_controller' do
-            it "returns controller" do
+            it "returns virtio controller" do
+                controller = Fog::Proxmox::DiskHelper.extract_controller(virtio1[:id])
+                assert_equal('virtio', controller)
+            end
+            it "returns scsi controller" do
                 controller = Fog::Proxmox::DiskHelper.extract_controller(scsi0[:id])
                 assert_equal('scsi', controller)
             end
@@ -73,6 +85,12 @@ require 'fog/proxmox/helpers/disk_helper'
                 assert_equal('local-lvm', storage)
                 assert_equal('local-lvm:vm-100-disk-1', volid)
                 assert_equal(8, size)
+            end
+            it "returns virtio get local storage volid and size" do
+                storage, volid, size = Fog::Proxmox::DiskHelper.extract_storage_volid_size(virtio[:virtio1])
+                assert_equal('local', storage)
+                assert_equal('local:108/vm-108-disk-1.qcow2', volid)
+                assert_equal(15, size)
             end
             it "returns scsi0 creation storage and volid" do
                 disk = Fog::Proxmox::DiskHelper.flatten(scsi0)
@@ -94,7 +112,6 @@ require 'fog/proxmox/helpers/disk_helper'
                 assert_nil size
             end
         end
-
         describe '#extract_size' do
             it "returns size" do
                 size = Fog::Proxmox::DiskHelper.extract_size(scsi[:scsi0])

--- a/spec/helpers/disk_helper_spec.rb
+++ b/spec/helpers/disk_helper_spec.rb
@@ -84,13 +84,13 @@ require 'fog/proxmox/helpers/disk_helper'
                 storage, volid, size = Fog::Proxmox::DiskHelper.extract_storage_volid_size(scsi[:scsi0])
                 assert_equal('local-lvm', storage)
                 assert_equal('local-lvm:vm-100-disk-1', volid)
-                assert_equal(8, size)
+                assert_equal(8589934592, size)
             end
             it "returns virtio get local storage volid and size" do
                 storage, volid, size = Fog::Proxmox::DiskHelper.extract_storage_volid_size(virtio[:virtio1])
                 assert_equal('local', storage)
                 assert_equal('local:108/vm-108-disk-1.qcow2', volid)
-                assert_equal(15, size)
+                assert_equal(16106127360, size)
             end
             it "returns scsi0 creation storage and volid" do
                 disk = Fog::Proxmox::DiskHelper.flatten(scsi0)
@@ -115,7 +115,11 @@ require 'fog/proxmox/helpers/disk_helper'
         describe '#extract_size' do
             it "returns size" do
                 size = Fog::Proxmox::DiskHelper.extract_size(scsi[:scsi0])
-                assert_equal(8, size)
+                assert_equal(8589934592, size)
+            end
+            it "returns size" do
+                size = Fog::Proxmox::DiskHelper.extract_size(virtio[:virtio1])
+                assert_equal(16106127360, size)
             end
         end
     end

--- a/spec/helpers/disk_helper_spec.rb
+++ b/spec/helpers/disk_helper_spec.rb
@@ -39,7 +39,7 @@ require 'fog/proxmox/helpers/disk_helper'
 	end
 
 	let(:virtio) do
-	    { virtio1: 'local:108/vm-108-disk-1.qcow2,size=15G' }
+	    { virtio1: 'local:108/vm-108-disk-1.qcow2,size=245'}
 	end
 
         let(:cdrom_none) do 
@@ -90,7 +90,7 @@ require 'fog/proxmox/helpers/disk_helper'
                 storage, volid, size = Fog::Proxmox::DiskHelper.extract_storage_volid_size(virtio[:virtio1])
                 assert_equal('local', storage)
                 assert_equal('local:108/vm-108-disk-1.qcow2', volid)
-                assert_equal(16106127360, size)
+                assert_equal(245, size)
             end
             it "returns scsi0 creation storage and volid" do
                 disk = Fog::Proxmox::DiskHelper.flatten(scsi0)
@@ -119,7 +119,7 @@ require 'fog/proxmox/helpers/disk_helper'
             end
             it "returns size" do
                 size = Fog::Proxmox::DiskHelper.extract_size(virtio[:virtio1])
-                assert_equal(16106127360, size)
+                assert_equal(245, size)
             end
         end
     end


### PR DESCRIPTION
This should fix #38. 
I basically modified the creation test in extract_storage_volid_size.
- changed the reported disk size to bytes
- added some tests