### PR TITLE
Specify image for rubocop job on gitlab-ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,7 @@ dependency_scanning:
     paths: [gl-dependency-scanning-report.json]
 
 rubocop:
+  image: ruby:2.5.1
   script:
     - bundle install --binstubs
     - rubocop


### PR DESCRIPTION
We forked the repository on our local gitlab-server, unfortunately the rubocop-job failed because our default docker-image has no ruby/bundle installed.

I picked `ruby:2.5.1`, because it is already used for one of the test-jobs.