### PR TITLE
Fix array result for Proxmox 5.3

### DIFF
--- a/lib/fog/compute/proxmox/models/server.rb
+++ b/lib/fog/compute/proxmox/models/server.rb
@@ -62,11 +62,11 @@ module Fog
 
         def type
           attributes[:type]
-        end 
+        end
 
         def request(name, body_params = {}, path_params = {})
           requires :node, :type
-          path = path_params.merge(node: node, type: type)
+          path = path_params.merge(node: node.to_s, type: type)
           task_upid = service.send(name, path, body_params)
           tasks.wait_for(task_upid)
         end

--- a/lib/fog/compute/proxmox/models/servers.rb
+++ b/lib/fog/compute/proxmox/models/servers.rb
@@ -56,8 +56,10 @@ module Fog
         def get(vmid)
           requires :node
           path_params = { node: node, type: type, vmid: vmid }
-          server_data = service.get_server_status path_params
+          server_data = service.get_server_status(path_params)
+          server_data = server_data.first if server_data.is_a?(Array)
           config_data = service.get_server_config path_params
+          config_data = config_data.first if config_data.is_a?(Array)
           data = server_data.merge(config_data).merge(node: node, vmid: vmid)
           new(data)
         end


### PR DESCRIPTION
Minor fix to allow retrieval of server/container information with Proxmox 5.3. 

It appears Proxmox 5.3 now returns an array instead of a single server which subsequently fails. I've made a backwards compatible fix by checking if the result is an array and taking the first element if thats the case.



Getting further into the process I run into more issues that seem to be 5.3 related. Is somebody already making a list of required changes or should I make pull requests per item? I'm worried about backward compatibility though since I only have a 5.3 instance to test against.


