### PR TITLE
Add mock data for requests

### DIFF
--- a/lib/fog/compute/proxmox/requests/action_server.rb
+++ b/lib/fog/compute/proxmox/requests/action_server.rb
@@ -41,6 +41,7 @@ module Fog
 
       # class Mock action_server request
       class Mock
+        def action_server(_path_params, _body_params); end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/check_vmid.rb
+++ b/lib/fog/compute/proxmox/requests/check_vmid.rb
@@ -35,6 +35,7 @@ module Fog
 
       # class Mock check_vmid collection
       class Mock
+        def check_vmid(_vmid); end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/clone_server.rb
+++ b/lib/fog/compute/proxmox/requests/clone_server.rb
@@ -40,6 +40,7 @@ module Fog
 
       # class Mock clone_server request
       class Mock
+        def clone_server(_path_params, _body_params); end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/create_backup.rb
+++ b/lib/fog/compute/proxmox/requests/create_backup.rb
@@ -38,6 +38,7 @@ module Fog
 
       # class Mock create_backup request
       class Mock
+        def create_backup(_path_params, _body_params); end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/create_server.rb
+++ b/lib/fog/compute/proxmox/requests/create_server.rb
@@ -39,6 +39,7 @@ module Fog
 
       # class Mock create_server request
       class Mock
+        def create_server(_path_params, _body_params); end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/create_snapshot.rb
+++ b/lib/fog/compute/proxmox/requests/create_snapshot.rb
@@ -40,7 +40,9 @@ module Fog
 
       # class Mock create_snapshot request
       class Mock
-        def create_snapshot; end
+        def create_snapshot(_path_params, _body_params)
+          'UPID:proxmox:00003E13:6F21770F:5E37E2D0:qmsnapshot:100:root@pam:'
+        end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/create_spice.rb
+++ b/lib/fog/compute/proxmox/requests/create_spice.rb
@@ -40,6 +40,7 @@ module Fog
 
       # class Mock create_spice request
       class Mock
+        def create_spice(_path_params, _body_params); end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/create_term.rb
+++ b/lib/fog/compute/proxmox/requests/create_term.rb
@@ -40,6 +40,7 @@ module Fog
 
       # class Mock create_term request
       class Mock
+        def create_term(_path_params, _body_params); end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/create_vnc.rb
+++ b/lib/fog/compute/proxmox/requests/create_vnc.rb
@@ -40,6 +40,7 @@ module Fog
 
       # class Mock create_vnc request
       class Mock
+        def create_vnc(_path_params, _body_params); end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/delete_server.rb
+++ b/lib/fog/compute/proxmox/requests/delete_server.rb
@@ -41,6 +41,7 @@ module Fog
 
       # class Mock delete_server request
       class Mock
+        def delete_server(_path_params, _body_params); end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/delete_snapshot.rb
+++ b/lib/fog/compute/proxmox/requests/delete_snapshot.rb
@@ -41,7 +41,9 @@ module Fog
 
       # class Mock delete_snapshot request
       class Mock
-        def delete_snapshot; end
+        def delete_snapshot(_path_params, _query_params)
+          'UPID:proxmox:00002CC5:646E24B1:5E1C7E26:qmdelsnapshot:100:root@pam:'
+        end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/delete_volume.rb
+++ b/lib/fog/compute/proxmox/requests/delete_volume.rb
@@ -33,7 +33,7 @@ module Fog
 
       # class Mock delete_volume request
       class Mock
-        def delete_volume; end
+        def delete_volume(_node, _storage, _volume); end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/get_node.rb
+++ b/lib/fog/compute/proxmox/requests/get_node.rb
@@ -37,7 +37,7 @@ module Fog
 
       # class Mock get_node request
       class Mock
-        def get_node; end
+        def get_node(_node); end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/get_node_statistics.rb
+++ b/lib/fog/compute/proxmox/requests/get_node_statistics.rb
@@ -25,7 +25,7 @@ module Fog
     class Proxmox
       # class Real get_node_statistics request
       class Real
-        def get_node_statistics(path_params,query_params)
+        def get_node_statistics(path_params, query_params)
           node = path_params[:node]
           output = path_params[:output]
           response = request(
@@ -40,7 +40,7 @@ module Fog
 
       # class Mock get_statistics request
       class Mock
-        def get_node_statistics; end
+        def get_node_statistics(_path_params, _query_params); end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/get_server_config.rb
+++ b/lib/fog/compute/proxmox/requests/get_server_config.rb
@@ -39,6 +39,24 @@ module Fog
 
       # class Mock get_server_config request
       class Mock
+        def get_server_config(_path_params)
+          {
+            :onboot => 0,
+            :memory => 512,
+            :ostype => 'l26',
+            :cores => 1,
+            :keyboard => 'en-us',
+            :digest => nil,
+            :smbios1 => nil,
+            :vmgenid => nil,
+            :balloon => 0,
+            :kvm => 0,
+            :cpu => 'cputype=kvm64',
+            :sockets => 1,
+            :bootdisk => 'scsi0',
+            :vga => 'std'
+          }
+        end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/get_server_status.rb
+++ b/lib/fog/compute/proxmox/requests/get_server_status.rb
@@ -39,6 +39,27 @@ module Fog
 
       # class Mock get_server_status request
       class Mock
+        def get_server_status(_path_params)
+          {
+            :netout => 0,
+            :ha => { 'managed' => 0 },
+            :mem => 0,
+            :vmid => '100',
+            :maxdisk => 8_589_934_592,
+            :diskread => 0,
+            :template => '',
+            :qmpstatus => 'stopped',
+            :diskwrite => 0,
+            :maxmem => 536_870_912,
+            :pid => nil,
+            :uptime => 0,
+            :status => 'stopped',
+            :cpu => 'cputype=kvm64',
+            :cpus => 1,
+            :disk => 0,
+            :netin => 0
+          }
+        end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/get_snapshot.rb
+++ b/lib/fog/compute/proxmox/requests/get_snapshot.rb
@@ -40,7 +40,7 @@ module Fog
 
       # class Mock get_snapshot request
       class Mock
-        def get_snapshot; end
+        def get_snapshot(_path_params); end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/get_storage.rb
+++ b/lib/fog/compute/proxmox/requests/get_storage.rb
@@ -37,7 +37,7 @@ module Fog
 
       # class Mock get_storage request
       class Mock
-        def get_storage; end
+        def get_storage(_node, _storage, _options = {}); end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/get_vnc.rb
+++ b/lib/fog/compute/proxmox/requests/get_vnc.rb
@@ -40,6 +40,7 @@ module Fog
 
       # class Mock get_vnc request
       class Mock
+        def get_vnc(_path_params, _query_params); end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/get_volume.rb
+++ b/lib/fog/compute/proxmox/requests/get_volume.rb
@@ -35,7 +35,7 @@ module Fog
 
       # class Mock get_volume request
       class Mock
-        def get_volume; end
+        def get_volume(_node, _storage, _volume); end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/list_nodes.rb
+++ b/lib/fog/compute/proxmox/requests/list_nodes.rb
@@ -35,7 +35,14 @@ module Fog
 
       # class Mock list_nodes request
       class Mock
-        def list_nodes; end
+        def list_nodes
+          [
+            {
+              'node' => 'proxmox',
+              'type' => 'node'
+            }
+          ]
+        end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/list_servers.rb
+++ b/lib/fog/compute/proxmox/requests/list_servers.rb
@@ -35,7 +35,78 @@ module Fog
 
       # class Mock list_servers request
       class Mock
-        def list_servers; end
+        def list_servers(_options = {})
+          if options[:type] == 'qemu'
+            [
+              {
+                'vmid' => '100',
+                'type' => 'qemu',
+                'node_id' => 'proxmox',
+                'config' => {
+                  'vmid' => '100',
+                  'description' => nil,
+                  'smbios1' => nil,
+                  'numa' => 0,
+                  'kvm' => 0,
+                  'vcpus' => nil,
+                  'cores' => 1,
+                  'bootdisk' => 'scsi0',
+                  'onboot' => 0,
+                  'boot' => nil,
+                  'agent' => '0',
+                  'scsihw' => nil,
+                  'sockets' => 1,
+                  'memory' => 512,
+                  'min_memory' => nil,
+                  'shares' => nil,
+                  'balloon' => 0,
+                  'cpu' => 'cputype=kvm64',
+                  'cpulimit' => nil,
+                  'cpuunits' => nil,
+                  'keyboard' => 'en-us',
+                  'vga' => 'std',
+                  'storage' => nil,
+                  'template' => '',
+                  'arch' => nil,
+                  'swap' => nil,
+                  'hostname' => nil,
+                  'nameserver' => nil,
+                  'searchdomain' => nil,
+                  'password' => nil,
+                  'startup' => nil,
+                  'console' => nil
+                },
+                'digest' => nil,
+                'maxdisk' => 8_589_934_592,
+                'disk' => 0,
+                'diskwrite' => 0,
+                'diskread' => 0,
+                'uptime' => 0,
+                'netout' => 0,
+                'netin' => 0,
+                'cpu' => 'cputype=kvm64',
+                'cpus' => 1,
+                'template' => '',
+                'status' => 'stopped',
+                'maxcpu' => nil,
+                'mem' => 0,
+                'maxmem' => 536_870_912,
+                'qmpstatus' => 'stopped',
+                'ha' => { 'managed' => 0 },
+                'pid' => nil,
+                'blockstat' => nil,
+                'balloon' => 0,
+                'ballooninfo' => nil,
+                'vmgenid' => nil,
+                'lock' => nil,
+                'maxswap' => nil,
+                'swap' => nil
+              }
+            ]
+          else
+            []
+          end
+        end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/list_snapshots.rb
+++ b/lib/fog/compute/proxmox/requests/list_snapshots.rb
@@ -36,7 +36,30 @@ module Fog
 
       # class Mock list_snapshots request
       class Mock
-        def list_snapshots; end
+        def list_snapshots(_path_params)
+          [
+            {
+              'name' => 'snapshot1',
+              'description' => 'latest snapshot',
+              'snaptime' => 1_578_057_452,
+              'vmstate' => 0,
+              'node_id' => 'proxmox',
+              'server_id' => '100',
+              'server_type' => 'qemu',
+              'vmgenid' => nil
+            },
+            {
+              'name' => 'snapshot2',
+              'description' => 'latest snapshot2',
+              'snaptime' => 1_578_058_452,
+              'vmstate' => 0,
+              'node_id' => 'proxmox',
+              'server_id' => '100',
+              'server_type' => 'qemu',
+              'vmgenid' => nil
+            }
+          ]
+        end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/list_storages.rb
+++ b/lib/fog/compute/proxmox/requests/list_storages.rb
@@ -35,7 +35,9 @@ module Fog
 
       # class Mock list_storages request
       class Mock
-        def list_storages; end
+        def list_storages(_node, _options = {})
+          []
+        end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/list_tasks.rb
+++ b/lib/fog/compute/proxmox/requests/list_tasks.rb
@@ -35,7 +35,9 @@ module Fog
 
       # class Mock list_tasks request
       class Mock
-        def list_tasks; end
+        def list_tasks(_node, _options = {})
+          []
+        end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/list_volumes.rb
+++ b/lib/fog/compute/proxmox/requests/list_volumes.rb
@@ -35,7 +35,9 @@ module Fog
 
       # class Mock list_volumes request
       class Mock
-        def list_volumes; end
+        def list_volumes(_node, _storage, _options = {})
+          []
+        end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/log_task.rb
+++ b/lib/fog/compute/proxmox/requests/log_task.rb
@@ -38,7 +38,9 @@ module Fog
 
       # class Mock status_task
       class Mock
-        def log_task(node, upid); end
+        def log_task(_node, _upid, options = {})
+          [{ 't' => 'TASK OK', 'n' => 1 }]
+        end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/migrate_server.rb
+++ b/lib/fog/compute/proxmox/requests/migrate_server.rb
@@ -37,7 +37,7 @@ module Fog
 
       # class Mock migrate_server request
       class Mock
-        def migrate_server; end
+        def migrate_server(_path_params, _body_params); end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/move_disk.rb
+++ b/lib/fog/compute/proxmox/requests/move_disk.rb
@@ -39,7 +39,7 @@ module Fog
 
       # class Mock move_disk request
       class Mock
-        def move_disk; end
+        def move_disk(_path_params, _body_params); end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/move_volume.rb
+++ b/lib/fog/compute/proxmox/requests/move_volume.rb
@@ -39,7 +39,7 @@ module Fog
 
       # class Mock move_volume request
       class Mock
-        def move_volume; end
+        def move_volume(_path_params, _body_params); end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/next_vmid.rb
+++ b/lib/fog/compute/proxmox/requests/next_vmid.rb
@@ -33,6 +33,7 @@ module Fog
 
       # class Mock next_vmid collection
       class Mock
+        def next_vmid; end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/resize_container.rb
+++ b/lib/fog/compute/proxmox/requests/resize_container.rb
@@ -39,7 +39,7 @@ module Fog
 
       # class Mock resize_container request
       class Mock
-        def resize_container; end
+        def resize_container(_path_params, _body_params); end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/resize_server.rb
+++ b/lib/fog/compute/proxmox/requests/resize_server.rb
@@ -36,7 +36,7 @@ module Fog
 
       # class Mock resize_server request
       class Mock
-        def resize_server; end
+        def resize_server(_path_params, _body_params); end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/rollback_snapshot.rb
+++ b/lib/fog/compute/proxmox/requests/rollback_snapshot.rb
@@ -39,7 +39,9 @@ module Fog
 
       # class Mock rollback_snapshot request
       class Mock
-        def rollback_snapshot; end
+        def rollback_snapshot(_path_params)
+          'UPID:proxmox:00002EBF:646E2BF3:5E1C7E39:qmrollback:100:root@pam:'
+        end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/status_task.rb
+++ b/lib/fog/compute/proxmox/requests/status_task.rb
@@ -37,7 +37,7 @@ module Fog
 
       # class Mock status_task
       class Mock
-        def status_task(node, upid); end
+        def status_task(_node, _upid); end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/stop_task.rb
+++ b/lib/fog/compute/proxmox/requests/stop_task.rb
@@ -34,7 +34,7 @@ module Fog
 
       # class Mock get_task collection
       class Mock
-        def stop_task(taskid); end
+        def stop_task(_node, _taskid); end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/template_server.rb
+++ b/lib/fog/compute/proxmox/requests/template_server.rb
@@ -37,6 +37,7 @@ module Fog
 
       # class Mock template_server request
       class Mock
+        def template_server(_path_params, _body_params); end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/update_server.rb
+++ b/lib/fog/compute/proxmox/requests/update_server.rb
@@ -40,6 +40,7 @@ module Fog
 
       # class Mock update_server request
       class Mock
+        def update_server(_path_params, _body_params); end
       end
     end
   end

--- a/lib/fog/compute/proxmox/requests/update_snapshot.rb
+++ b/lib/fog/compute/proxmox/requests/update_snapshot.rb
@@ -38,7 +38,7 @@ module Fog
 
       # class Mock update_snapshot request
       class Mock
-        def update_snapshot; end
+        def update_snapshot(_path_params, _body_params); end
       end
     end
   end


### PR DESCRIPTION
Adding mocked data for requests. This can help in plugins tests which uses Fog::mock! to mock fog-proxmox mocked data.