### PR TITLE
Remove ipaddress dependency

### DIFF
--- a/fog-proxmox.gemspec
+++ b/fog-proxmox.gemspec
@@ -60,6 +60,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'fog-core',  '~> 2.1'
   spec.add_dependency 'fog-json',  '~> 1.2'
-  spec.add_dependency 'ipaddress', '~> 0.8'
   spec.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
In e8af185c82b0f7631925cb8e7c7844c29e0c7750 it was added as a dependency but I can't see where it's used.