### PR TITLE
ci: fixes coverage prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         GIT_BRANCH: ${{ github.ref }}
         GIT_COMMIT_SHA: ${{ github.sha }}
       with:
-        workingDirectory: coverage
+        workingDirectory: ${{github.workspace}}
         debug: true
         coverageLocations: |
           ${{github.workspace}}/coverage/coverage.json:simplecov


### PR DESCRIPTION
codeclimate test coverage file uploaded has wrong path (prefix):

```json
{
  "message": "Invalid path part \"/\"",
  "file_document": "{\"_id\"=>BSON::ObjectId('6388be0360599800f8000e3d'), \"type\"=>\"test_file_reports\", \"blob_id\"=>\"a2df090cb727749d97cdb71ed8a8f3e298539467\", \"coverage\"=>\"[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,1,null,1,1,1,null,1,1,1,1,1,null,1,5,null,null,1,2,2,null,null,1,2,null,null,null,null,null]\", \"covered_percent\"=>100, \"covered_strength\"=>1.4375, \"line_counts\"=>{\"missed\"=>0, \"covered\"=>16, \"total\"=>16}, \"path\"=>\"/home/runner/work/fog-proxmox/fog-proxmox/lib/fog/proxmox/compute/models/snapshots.rb\", \"test_report_id\"=>BSON::ObjectId('6388be0360599800f8000dbd')}"
```