### PR TITLE
Ship only minimal files in the gem

### DIFF
--- a/fog-proxmox.gemspec
+++ b/fog-proxmox.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/fog/fog-proxmox'
   spec.license       = 'GPL-3.0'
 
-  spec.files         = `git ls-files -z`.split("\x0")
+  spec.files         = `git ls-files -z CHANGELOG.md LICENSE README.md docs examples lib spec`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.5'


### PR DESCRIPTION
Prior to this the resulting gem included many unrelated files for real use cases, such as CI files. This only includes the files relevant to run it, plus some files you should ship.

I'm a bit unsure about the bin directory. It now lists them, but they're no longer shipped. I also question if they should even be in the git repo at all, given they're bundler stubs.