### PR TITLE
Implement `Storage#upload()` request

### DIFF
--- a/lib/fog/proxmox/core.rb
+++ b/lib/fog/proxmox/core.rb
@@ -93,7 +93,7 @@ module Fog
           authenticate! if expired?
           request_options = params.merge(path: "#{@path}/#{params[:path]}",
                                          headers: @auth_token.headers(
-                                           params[:method], params.respond_to?(:headers) ? params[:headers] : {}, {}
+                                           params[:method], {}, params.key?(:headers) ? params[:headers] : {}
                                          ))
           response = @connection.request(request_options)
         rescue Excon::Errors::Unauthorized => e

--- a/lib/fog/proxmox/storage.rb
+++ b/lib/fog/proxmox/storage.rb
@@ -22,8 +22,57 @@ module Fog
   module Proxmox
     # Procmox storage service
     class Storage < Fog::Service
+      requires :proxmox_url, :proxmox_auth_method
+      recognizes :proxmox_token, :proxmox_tokenid, :proxmox_userid, :persistent, :proxmox_username, :proxmox_password
+
       # Models
-      model_path 'fog/proxmox/storage'
+      model_path 'fog/proxmox/storage/models'
+
+      request_path 'fog/proxmox/storage/requests'
+
+      request :upload
+
+      # Mock class
+      class Mock
+        attr_reader :config
+
+        def initialize(options = {})
+          @proxmox_uri = URI.parse(options[:proxmox_url])
+          @proxmox_auth_method = options[:proxmox_auth_method]
+          @proxmox_tokenid = options[:proxmox_tokenid]
+          @proxmox_userid = options[:proxmox_userid]
+          @proxmox_username = options[:proxmox_username]
+          @proxmox_password = options[:proxmox_password]
+          @proxmox_token = options[:proxmox_token]
+          @proxmox_path = @proxmox_uri.path
+          @config = options
+        end
+      end
+
+      # Real class
+      class Real
+        include Fog::Proxmox::Core
+
+        def self.not_found_class
+          Fog::Proxmox::Storage::NotFound
+        end
+
+        def config
+          self
+        end
+
+        def config_service?
+          true
+        end
+
+        private
+
+        def configure(source)
+          source.instance_variables.each do |v|
+            instance_variable_set(v, source.instance_variable_get(v))
+          end
+        end
+      end
     end
   end
 end

--- a/lib/fog/proxmox/storage/requests/upload.rb
+++ b/lib/fog/proxmox/storage/requests/upload.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+
+module Fog
+  module Proxmox
+    class Storage
+      # class Real upload
+      class Real
+        def upload(path_params, body_params)
+          node = path_params[:node]
+          storage = path_params[:storage]
+          body, content_type = self.class.build_formdata(body_params)
+          request(
+            expects: [200],
+            method: 'POST',
+            path: "nodes/#{node}/storage/#{storage}/upload",
+            body: body,
+            headers: { 'Content-Type' => content_type }
+          )
+        end
+
+        private
+        def self.build_formdata(body_params)
+            boundary = '-' * 30 + SecureRandom.hex(15)
+
+            body = "--#{boundary}" + Excon::CR_NL
+            body << 'Content-Disposition: form-data; name="content"' << Excon::CR_NL << Excon::CR_NL
+            body << body_params[:content] << Excon::CR_NL
+            body << "--#{boundary}" << Excon::CR_NL
+            body << %{Content-Disposition: form-data; name="filename"; filename="#{body_params[:filename]}"} << Excon::CR_NL
+            body << "Content-Type: " << (body_params[:content_type] || 'application/octet-stream') << Excon::CR_NL << Excon::CR_NL
+            body << body_params[:file].read << Excon::CR_NL
+            body << "--#{boundary}--" << Excon::CR_NL
+
+            [body, %{multipart/form-data; boundary=#{boundary}}]
+        end
+      end
+
+      # class Mock upload
+      class Mock
+      end
+    end
+  end
+end


### PR DESCRIPTION
`POST /api2/json/nodes/{node}/storage/{storage}/upload` API allows to upload ISO images which can then be used for VM installation.
See https://pve.proxmox.com/pve-docs/api-viewer/index.html#/nodes/{node}/storage/{storage}/upload

This PR implements this API allowing to
```ruby
storage = Fog::Storage.new(provider: :proxmox, **params)
isopath = 'my.iso'
file = File.open(isopath, 'rb')
storage.upload({
        node: node,
        storage: storage
    },
    {
        content: 'iso',
        file: file,
        filename: File.basename(isopath)
    }
)
```
