### PR TITLE
Update GitHub upload-artifact to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Run vulnerabilities check
       run: bundle exec rake audit
     - name: Upload simplecov results for coverage
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: coverage
         path: coverage/


### PR DESCRIPTION
#99 test failed because of

> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v1`.
> Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

v1 is deprecated and causes tests to fail so this PR updates upload-artifact to v4
