### PR TITLE
Fix rubocop errors

### DIFF
--- a/lib/fog/proxmox/helpers/disk_helper.rb
+++ b/lib/fog/proxmox/helpers/disk_helper.rb
@@ -141,23 +141,23 @@ module Fog
       end
 
       def self.disk?(id)
-        DISKS_REGEXP.match(id) ? true : false
+        DISKS_REGEXP.match(id) || false
       end
 
       def self.cdrom?(value)
-        CDROM_REGEXP.match(value) ? true : false
+        CDROM_REGEXP.match(value) || false
       end
 
       def self.server_disk?(id)
-        SERVER_DISK_REGEXP.match(id) ? true : false
+        SERVER_DISK_REGEXP.match(id) || false
       end
 
       def self.rootfs?(id)
-        ROOTFS_REGEXP.match(id) ? true : false
+        ROOTFS_REGEXP.match(id) || false
       end
 
       def self.mount_point?(id)
-        MOUNT_POINT_REGEXP.match(id) ? true : false
+        MOUNT_POINT_REGEXP.match(id) || false
       end
 
       def self.container_disk?(id)
@@ -165,11 +165,11 @@ module Fog
       end
 
       def self.template?(volid)
-        TEMPLATE_REGEXP.match(volid) ? true : false
+        TEMPLATE_REGEXP.match(volid) || false
       end
 
       def self.cloud_init?(volid)
-        CLOUD_INIT_REGEXP.match(volid) ? true : false
+        CLOUD_INIT_REGEXP.match(volid) || false
       end
 
       def self.of_type?(disk_h, vm_type)

--- a/lib/fog/proxmox/helpers/nic_helper.rb
+++ b/lib/fog/proxmox/helpers/nic_helper.rb
@@ -119,7 +119,7 @@ module Fog
       end
 
       def self.nic?(id)
-        NICS_REGEXP.match(id) ? true : false
+        NICS_REGEXP.match(id) || false
       end
 
       def self.extract_ip(nic_value)


### PR DESCRIPTION
Style/RedundantCondition: Use double pipes || instead