### PR TITLE
Fix rubocop errors

### DIFF
--- a/lib/fog/proxmox/string.rb
+++ b/lib/fog/proxmox/string.rb
@@ -22,8 +22,8 @@ module Fog
     # module String mixins
     module String
       def self.to_boolean(text)
-        return true if text == true || text =~ (/(true|t|yes|y|1)$/i)
-        return false if text == false || text.empty? || text =~ (/(false|f|no|n|0)$/i)
+        return true if text == true || text =~ /(true|t|yes|y|1)$/i
+        return false if text == false || text.empty? || text =~ /(false|f|no|n|0)$/i
 
         raise ArgumentError, "invalid value for Boolean: \"#{text}\""
       end


### PR DESCRIPTION
Style/RedundantParentheses: Don't use parentheses around a literal