### PR TITLE
Fixes #130 - Use modern /pools?poolid= endpoint in get_pool (nested pool support)

### DIFF
--- a/lib/fog/proxmox/identity/requests/get_pool.rb
+++ b/lib/fog/proxmox/identity/requests/get_pool.rb
@@ -24,11 +24,20 @@ module Fog
       # class Real get_pool collection
       class Real
         def get_pool(poolid)
-          request(
+          # Use the modern GET /pools?poolid=X endpoint. The historical
+          # GET /pools/{poolid} is deprecated in Proxmox VE and returns
+          # 501 Not Implemented for nested pool ids (e.g. 'foo/bar'),
+          # which breaks Pools#all against any cluster that uses them.
+          # See fog/fog-proxmox#130.
+          response = request(
             expects: [200],
             method: 'GET',
-            path: "pools/#{poolid}"
+            path: 'pools',
+            query: { poolid: poolid }
           )
+          # The endpoint returns an array of matching pools; unwrap the
+          # single element to keep the historical return signature.
+          response.is_a?(Array) ? (response.first || {}) : response
         end
       end
 


### PR DESCRIPTION
## Summary

Fixes #130

The historical `GET /pools/{poolid}` endpoint is deprecated in Proxmox VE and — since PVE 8.1 introduced **nested pools** (with GUI support in 9.1.5) — returns `501 Not Implemented` for any pool id that contains a slash (e.g. `foreman_testing/laph`).

Because `Pools#all` fires a per-pool `get_pool` call for every entry returned by `list_pools`, the presence of a single nested pool breaks `Pools#all` against the whole cluster. Downstream this takes out the Foreman plugin's metadata endpoint entirely — see theforeman/foreman_fog_proxmox#476.

## Change

`Real#get_pool` now uses the endpoint the Proxmox docs explicitly recommend:

```
GET /pools?poolid=X
```

Because that endpoint returns an *array* of matching pools instead of a bare hash, we unwrap the single element so callers of `get_pool` (in particular `Pools#all`) see the same shape as before.

## Reproduction (against a live PVE 8.1+ cluster with nested pools)

```ruby
require 'fog/proxmox'
service = Fog::Proxmox::Identity.new(...)
service.pools.all
# master:  raises Excon::Error::HTTPStatusError 501 Not Implemented for
#          GET /api2/json/pools/foreman_testing/laph
# branch:  succeeds; all pools including nested ones are returned
```

## Testing note

The existing pool spec relies on a recorded VCR cassette (`spec/fixtures/proxmox/identity/pools.yml`) that was made against a PVE without nested pools, so a fresh cassette recorded on a PVE 8.1+ cluster would be needed to cover this endpoint change. I don't have a suitable PVE cluster on hand for the recording — happy to add a spec if a maintainer can generate the cassette, or if a mock-based test approach is preferred I can port `spec/fixtures/proxmox/identity` to that.

## AI usage disclosure

The diagnosis, the code change a the wording of this PR were done with Claude (Anthropic) jako an assistant. Reproduction happened on my own production Proxmox setup that has nested pools; I reviewed the change before pushing. Also noted as an `Assisted-By` trailer on the commit.
