### PR TITLE
Fixes #108 - Read API error message from the body, not the reason-phrase

### DIFF
--- a/lib/fog/proxmox/compute/models/servers.rb
+++ b/lib/fog/proxmox/compute/models/servers.rb
@@ -18,6 +18,7 @@
 # along with Fog::Proxmox. If not, see <http://www.gnu.org/licenses/>.
 
 require 'fog/proxmox/compute/models/server'
+require 'fog/proxmox/errors'
 
 module Fog
   module Proxmox
@@ -53,9 +54,8 @@ module Fog
             status_data = service.get_server_status path_params
             config_data = service.get_server_config path_params
           rescue StandardError => e
-            if e.respond_to?('response') && e.response.respond_to?('data') && e.response.data.has_key?(:reason_phrase) && e.response.data[:reason_phrase].end_with?('does not exist')
-              raise(Fog::Errors::NotFound)
-            end
+            message = Fog::Proxmox::Errors.message(e)
+            raise(Fog::Errors::NotFound) if message&.end_with?('does not exist')
 
             raise(e)
           else

--- a/lib/fog/proxmox/errors.rb
+++ b/lib/fog/proxmox/errors.rb
@@ -17,9 +17,46 @@
 # You should have received a copy of the GNU General Public License
 # along with Fog::Proxmox. If not, see <http://www.gnu.org/licenses/>.
 
+require 'fog/json'
+
 module Fog
   module Proxmox
     module Errors
+      # Returns the Proxmox error message carried by an Excon error response.
+      #
+      # The message is read from the JSON body ({"message": "...", "data": null})
+      # in preference to the HTTP reason-phrase, because a reason-phrase is not a
+      # reliable channel for information: it may be rewritten by an intermediary
+      # (a reverse proxy replacing Proxmox's "500 Configuration file '...' does not
+      # exist" with a generic "500 Internal Server Error"), translated for a locale,
+      # or discarded when the message is forwarded over another version of HTTP.
+      # RFC 9112 section 4 therefore says a client SHOULD ignore it. See
+      # https://datatracker.ietf.org/doc/html/rfc9112#section-4-8 and
+      # https://github.com/fog/fog-proxmox/issues/108
+      #
+      # The reason-phrase is kept as a fallback for responses without a JSON body.
+      def self.message(error)
+        return nil unless error.respond_to?(:response) && error.response.respond_to?(:data)
+
+        data = error.response.data
+        # ::Hash, as Hash resolves to Fog::Proxmox::Hash in this namespace.
+        return nil unless data.is_a?(::Hash)
+
+        message_from_body(data[:body]) || data[:reason_phrase]
+      end
+
+      def self.message_from_body(body)
+        decoded = Fog::JSON.decode(body)
+        return nil unless decoded.is_a?(::Hash)
+
+        message = decoded['message']
+        # Proxmox terminates its messages with a newline.
+        message.strip if message.is_a?(String)
+      rescue Fog::JSON::DecodeError
+        nil
+      end
+      private_class_method :message_from_body
+
       # class ServiceError
       class ServiceError < Fog::Errors::Error
         attr_reader :response_data

--- a/spec/compute/servers_spec.rb
+++ b/spec/compute/servers_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Copyright 2018 Tristan Robert
+
+# This file is part of Fog::Proxmox.
+
+# Fog::Proxmox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# Fog::Proxmox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with Fog::Proxmox. If not, see <http://www.gnu.org/licenses/>.
+
+require 'spec_helper'
+require 'fog/proxmox/compute/models/servers'
+
+describe Fog::Proxmox::Compute::Servers do
+  # Raises the Excon error a Proxmox 500 produces, with the reason-phrase an
+  # intermediary such as a reverse proxy would have left in place of the
+  # upstream one.
+  def service_raising(body, reason_phrase)
+    response = Excon::Response.new(status: 500, reason_phrase: reason_phrase, body: body)
+    error = Excon::Errors::InternalServerError.new('Expected([200]) <=> Actual(500)', nil, response)
+    service = Minitest::Mock.new
+    service.expect(:get_server_status, nil) { raise error }
+    service
+  end
+
+  let(:not_found_body) do
+    Fog::JSON.encode(
+      'message' => "Configuration file 'nodes/example-prox01/qemu-server/153157505.conf' does not exist\n",
+      'data' => nil
+    )
+  end
+
+  def servers(service)
+    Fog::Proxmox::Compute::Servers.new(service: service, node_id: 'pve', type: 'qemu')
+  end
+
+  describe '#get' do
+    it 'raises NotFound when the body says the config does not exist' do
+      service = service_raising(not_found_body, 'Internal Server Error')
+      assert_raises(Fog::Errors::NotFound) { servers(service).get('153157505') }
+    end
+
+    it 'raises the original error when the body reports another failure' do
+      service = service_raising(Fog::JSON.encode('message' => "no such user ('root@pam')\n"), 'Internal Server Error')
+      assert_raises(Excon::Errors::InternalServerError) { servers(service).get('153157505') }
+    end
+  end
+end

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# Copyright 2018 Tristan Robert
+
+# This file is part of Fog::Proxmox.
+
+# Fog::Proxmox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# Fog::Proxmox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with Fog::Proxmox. If not, see <http://www.gnu.org/licenses/>.
+
+require 'spec_helper'
+require 'fog/proxmox/errors'
+
+describe Fog::Proxmox::Errors do
+  # Builds the Excon error a Proxmox 500 raises, with the reason-phrase an
+  # intermediary would have left in place of the upstream one.
+  def error_for(body, reason_phrase)
+    response = Excon::Response.new(status: 500, reason_phrase: reason_phrase, body: body)
+    Excon::Errors::InternalServerError.new('Expected([200]) <=> Actual(500)', nil, response)
+  end
+
+  let(:proxmox_message) do
+    "Configuration file 'nodes/example-prox01/qemu-server/153157505.conf' does not exist"
+  end
+
+  let(:proxmox_body) do
+    Fog::JSON.encode('message' => "#{proxmox_message}\n", 'data' => nil)
+  end
+
+  describe '#message' do
+    it 'returns the message of the body when the reason phrase was rewritten' do
+      error = error_for(proxmox_body, 'Internal Server Error')
+      assert_equal proxmox_message, Fog::Proxmox::Errors.message(error)
+    end
+
+    it 'returns the message of the body when the reason phrase was kept' do
+      error = error_for(proxmox_body, proxmox_message)
+      assert_equal proxmox_message, Fog::Proxmox::Errors.message(error)
+    end
+
+    it 'falls back on the reason phrase when the body is not JSON' do
+      error = error_for('<html>502 Bad Gateway</html>', 'Bad Gateway')
+      assert_equal 'Bad Gateway', Fog::Proxmox::Errors.message(error)
+    end
+
+    it 'falls back on the reason phrase when the body is empty' do
+      error = error_for('', 'Internal Server Error')
+      assert_equal 'Internal Server Error', Fog::Proxmox::Errors.message(error)
+    end
+
+    it 'falls back on the reason phrase when the body carries no message' do
+      error = error_for(Fog::JSON.encode('data' => nil), 'Internal Server Error')
+      assert_equal 'Internal Server Error', Fog::Proxmox::Errors.message(error)
+    end
+
+    it 'returns nil when the error has no response' do
+      assert_nil Fog::Proxmox::Errors.message(StandardError.new('boom'))
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #108.

`Servers#get` classified a failed VM lookup as "not found" by matching the HTTP
reason-phrase. Behind a reverse proxy that rewrites the reason-phrase, that match
fails and the raw `500` escapes instead of `Fog::Errors::NotFound`, even though the
response body carries the message. This reads the message from the JSON body
instead, keeping the reason-phrase as a fallback.

## Root cause

`lib/fog/proxmox/compute/models/servers.rb`:

```ruby
rescue StandardError => e
  if e.respond_to?('response') && e.response.respond_to?('data') && e.response.data.has_key?(:reason_phrase) && e.response.data[:reason_phrase].end_with?('does not exist')
    raise(Fog::Errors::NotFound)
  end

  raise(e)
```

Proxmox does put the message in the reason-phrase
(`500 Configuration file 'nodes/pve/qemu-server/100.conf' does not exist`), so this
works on a direct connection. But the reason-phrase is not a channel that survives
the trip. Per RFC 9112, [section 4](https://datatracker.ietf.org/doc/html/rfc9112#section-4-8):

> A client SHOULD ignore the reason-phrase content because it is not a reliable
> channel for information (it might be translated for a given locale, overwritten by
> intermediaries, or discarded when the message is forwarded via other versions of HTTP).

As reported in #108, Caddy in front of the Proxmox API replaces the upstream phrase
with a generic `500 Internal Server Error`, the `end_with?` match fails, and the error
is re-raised. Downstream (`foreman_fog_proxmox`) this surfaces as
*"ComputeResourcesVm not found"* for any VM on a node other than the one the proxy
talks to.

The same text is present in the body, which no intermediary touches:

```json
{"message":"Configuration file 'nodes/example-prox01/qemu-server/153157505.conf' does not exist\n","data":null}
```

## Change

Two files, one call site — `reason_phrase` appears exactly once in `lib/`.

- `lib/fog/proxmox/errors.rb`: adds `Fog::Proxmox::Errors.message(error)`, which reads
  `message` out of the JSON body (stripping the newline Proxmox appends) and falls back
  to `reason_phrase` when the body is absent, empty, not JSON, or carries no `message`.
  Responses that never had a JSON body therefore behave exactly as before.
- `lib/fog/proxmox/compute/models/servers.rb`: `get` matches `'does not exist'` against
  that message. The decision itself is unchanged and stays at the call site.

I put the helper in `errors.rb` rather than inlining it in `servers.rb` so the
transport concern (*where* the message is read from) is testable on its own, without a
cassette. It is a module function next to `ServiceError`, which already extracts
`message` from the body — no change to existing behaviour there.

One wrinkle worth flagging for review: the guard uses `data.is_a?(::Hash)`, explicitly
top-level, because inside `Fog::Proxmox` the constant `Hash` resolves to
`Fog::Proxmox::Hash`. Without the `::` the guard silently returns `nil` for every error.
There is a comment on that line.

## Tests

Both new specs are cassette-free — they build the `Excon::Response`/`Excon::Error` pair
directly, so no maintainer needs to record anything.

- `spec/errors_spec.rb` (6 tests) covers `Errors.message`: message taken from the body
  when the reason-phrase was rewritten to `Internal Server Error`, and when it was left
  intact; plus the fallback path for a non-JSON body, an empty body, a JSON body with no
  `message`, and an error with no response at all.
- `spec/compute/servers_spec.rb` (2 tests) covers the reported symptom via `Servers#get`:
  `Fog::Errors::NotFound` for a `does not exist` body behind a generic reason-phrase, and
  the original error still raised for any other failure.

`spec/compute/servers_spec.rb` fails on current `master` (`[Fog::Errors::NotFound]
exception expected, not Excon::Error::InternalServerError`) and passes with this change.

Ran on Ruby 3.0.2 in a Linux container, not via `bundle` (the gems were installed
directly, as my machine's own Ruby is older than the gemspec's `>= 2.7`): `errors_spec`,
`compute/servers_spec`, `hash_spec`, all of `spec/helpers/`, plus `compute_spec` and
`identity_spec` (VCR) all pass — 143 runs, 0 failures. `network_spec.rb` aborts during
load in my setup, but it does so identically on unmodified `master`, so it is unrelated
to this change. I have not run RuboCop.

## Follow-up (not in this PR)

`foreman_fog_proxmox` has its own `token_expired?(e)` that reads
`e.response.reason_phrase`, which is the same anti-pattern and would be affected by the
same proxy. That is a separate repo, so I have left it alone here.

## AI usage disclosure

The diagnosis and this change were worked out with Claude (Anthropic) as an assistant,
starting from the analysis in #108. I have not reproduced the original setup (Proxmox
behind a reverse proxy that rewrites the reason-phrase) myself — the fix follows the
reporter's diagnosis and RFC 9112, and is covered by the tests added here, which I did
run. The commit carries an `Assisted-By: Claude (Anthropic)` trailer.
