### PR TITLE
Fixes #118 - do not list volumes of a storage inactive on the node

### DIFF
--- a/lib/fog/proxmox/compute/models/storage.rb
+++ b/lib/fog/proxmox/compute/models/storage.rb
@@ -49,15 +49,32 @@ module Fog
           Fog::Proxmox::Attributes.set_attr_and_sym('node_id', attributes, new_attributes)
           Fog::Proxmox::Attributes.set_attr_and_sym('storage', attributes, new_attributes)
           requires :node_id, :storage
-          initialize_volumes
+          # volumes are initialized last, as it depends on the other attributes
+          # having been merged already (see #active?)
           super(new_attributes)
+          initialize_volumes
+        end
+
+        # Proxmox evaluates a storage per node: a storage may be defined
+        # cluster-wide and still be unusable on this node, because it is
+        # disabled or restricted to other nodes. Such a storage is still listed
+        # by GET /nodes/{node}/storage, but with active (and enabled) set to 0.
+        # active is only known for storages built from an API response, so a
+        # missing value is assumed to be active.
+        def active?
+          active.nil? || ![0, '0', false].include?(active)
         end
 
         private
 
+        # Listing the content of a storage that is not active on this node fails
+        # with "storage 'x' is not available on node 'y'" (HTTP 500), so give it
+        # an empty, already loaded collection rather than let it lazily query
+        # the API. See https://github.com/fog/fog-proxmox/issues/118
         def initialize_volumes
-          attributes[:volumes] =
-            Fog::Proxmox::Compute::Volumes.new(service: service, node_id: node_id, storage_id: identity)
+          volumes = Fog::Proxmox::Compute::Volumes.new(service: service, node_id: node_id, storage_id: identity)
+          volumes.load([]) unless active?
+          attributes[:volumes] = volumes
         end
       end
     end

--- a/spec/compute_spec.rb
+++ b/spec/compute_spec.rb
@@ -93,6 +93,43 @@ describe Fog::Proxmox::Compute do
     end
   end
 
+  # https://github.com/fog/fog-proxmox/issues/118
+  it 'Does not request volumes of a storage inactive on the node' do
+    # Proxmox lists a storage that is disabled or restricted to other nodes with
+    # active = 0, and answers its content endpoint with HTTP 500
+    # "storage 'nas' is not available on node 'pve'", so it must not be queried.
+    calls = []
+    service = Object.new
+    service.define_singleton_method(:list_volumes) do |*args|
+      calls << args
+      []
+    end
+    storage = Fog::Proxmox::Compute::Storage.new(
+      service: service, node_id: 'pve', storage: 'nas',
+      content: 'images,backup', active: 0, enabled: 0
+    )
+    _(storage.active?).must_equal false
+    _(storage.volumes).must_be_empty
+    _(calls).must_be_empty
+  end
+
+  it 'Requests volumes of a storage active on the node' do
+    volid = 'local:vztmpl/debian-10.0-standard_10.0-1_amd64.tar.gz'
+    calls = []
+    service = Object.new
+    service.define_singleton_method(:list_volumes) do |*args|
+      calls << args
+      [{ 'volid' => volid, 'content' => 'vztmpl' }]
+    end
+    storage = Fog::Proxmox::Compute::Storage.new(
+      service: service, node_id: 'pve', storage: 'local',
+      content: 'vztmpl,iso,backup', active: 1, enabled: 1
+    )
+    _(storage.active?).must_equal true
+    _(storage.volumes.map(&:volid)).must_equal [volid]
+    _(calls).must_equal [['pve', 'local', {}]]
+  end
+
   it 'CRUD servers' do
     VCR.use_cassette('servers') do
       node_name = 'pve'


### PR DESCRIPTION
## Summary

Fixes #118.

A storage that is restricted to a subset of nodes (or disabled) makes
`Server#backups` / `Server#images` — and any direct use of `storage.volumes` —
fail with:

```
HTTP/1.1 500 storage '[storage]' is not available on node '[node1]'
```

No volumes are now returned for storages that Proxmox reports as inactive on
the node, and no request is issued for them.

## Root cause

`GET /nodes/{node}/storage` does **not** hide a storage that is unusable on that
node. In [`PVE::Storage::storage_info`](https://github.com/proxmox/pve-storage/blob/master/src/PVE/Storage.pm) a storage is skipped only when the caller passes a
content filter; otherwise it is listed with `enabled`/`active` set to `0`:

```perl
my $storage_enabled = defined(storage_check_enabled($cfg, $storeid, undef, 1));

if (defined($content)) {
    ...
    next if !$want_ctype || !$storage_enabled;   # only filtered when $content is given
}

$info->{$storeid} = {
    ...
    active  => 0,
    enabled => $storage_enabled ? 1 : 0,
};
```

`storage_check_enabled` folds the node restriction in (via `storage_check_node`),
which is where the reported message comes from:

```perl
die "storage '$storeid' is not available on node '$node'\n" if !$noerr;
```

`Storages#all` calls `list_storages(node_id, filters)` with no `content` param, so
the unavailable storage **is** returned. `Storage#initialize` then built a
`Volumes` collection for it unconditionally:

```ruby
requires :node_id, :storage
initialize_volumes
super(new_attributes)
```

```ruby
def initialize_volumes
  attributes[:volumes] =
    Fog::Proxmox::Compute::Volumes.new(service: service, node_id: node_id, storage_id: identity)
end
```

`Fog::Collection` is lazy, so the failure does not occur in `initialize` itself — it
occurs on first touch of the collection, which issues
`GET /nodes/{node}/storage/{storage}/content` and gets the 500. The reporter's
mention of `server.rb` is on point, because that is the code that touches it for
every storage:

```ruby
def list(content)
  storages = node.storages.list_by_content_type content
  volumes = []
  storages.each { |storage| volumes += storage.volumes.list_by_content_type_and_by_server(content, identity) }
  volumes
end
```

`list_by_content_type` filters client-side on top of an unfiltered `all`, so it does
not benefit from the server-side filtering above. One node-local storage on another
node therefore breaks `backups` / `images` cluster-wide.

## Change

`lib/fog/proxmox/compute/models/storage.rb`:

- `initialize_volumes` is moved after `super(new_attributes)`. It has to be: the
  attributes are merged by `super`, so `active` is still `nil` at the point where
  the old code ran, and any guard placed there could not read it.
- A storage known to be inactive gets an **empty, already loaded** `Volumes`
  collection, so it never lazily queries the API.
- Adds a public `Storage#active?` predicate.

Two notes on the suggestion in the issue, which is otherwise an accurate diagnosis:

- Returning an empty collection rather than skipping the attribute (leaving
  `volumes` `nil`) keeps `Server#list` above working — with `nil` it would trade the
  500 for a `NoMethodError`.
- The guard checks `active` rather than `enabled`. PVE only probes `active` for
  storages it already considers enabled (`next if !$info->{$storeid}->{enabled};`),
  so `active == 1` implies `enabled == 1`; `active` is the stricter of the two and
  additionally covers an enabled storage that is momentarily offline. Also worth
  flagging: a literal `if enabled` would not work, because PVE returns `0`/`1`
  integers and `0` is truthy in Ruby.

`active` is only known for storages built from an API response, so a missing value
is still treated as active — behaviour is unchanged for locally built models.

## Tests

Two cases added to `spec/compute_spec.rb`, no new cassette needed — the storage
model is built directly and the service is a stub that records calls:

- `Does not request volumes of a storage inactive on the node` — asserts
  `volumes` is empty **and** that `list_volumes` was never called.
- `Requests volumes of a storage active on the node` — asserts the lazy fetch
  still happens for an active storage.

Verified the regression test actually bites: with only the `volumes.load([]) unless active?`
guard removed, it fails with

```
Expected [["pve", "nas", {}]] to be empty.
```

which is precisely the `GET /nodes/pve/storage/nas/content` request that returns
the 500.

I ran the suite on Ruby 3.0.2 (Ruby 2.6 locally is below the gem's 2.7 minimum):
`compute_spec` 8 runs / 110 assertions, plus `identity_spec`, `hash_spec` and all
`spec/helpers/*` green. `rubocop` reports no offenses on the changed lib file
(run with core cops; I could not install the full plugin set locally).

## AI usage disclosure

The diagnosis and this change were worked out with Claude (Anthropic) as an
assistant, starting from the analysis in #118. I have **not** reproduced the
original setup — a storage restricted to a single node in a multi-node cluster —
on my own hardware. The reasoning above is derived from the fog-proxmox source,
the pve-storage source linked above, and the reporter's diagnosis, and is covered
by the tests added here; the stubbed service in those tests is my model of the
API's behaviour, not a recording of a real one. Also noted as an `Assisted-By`
trailer on the commit. Confirmation against a real multi-node cluster would be
very welcome.
