### PR TITLE
Add cluster status API endpoint

### DIFF
--- a/lib/fog/proxmox/compute.rb
+++ b/lib/fog/proxmox/compute.rb
@@ -52,6 +52,7 @@ module Fog
 
       # Manage nodes cluster
       request :list_nodes
+      request :cluster_status
       request :get_node_statistics
       request :next_vmid
       # Manage servers

--- a/lib/fog/proxmox/compute/requests/cluster_status.rb
+++ b/lib/fog/proxmox/compute/requests/cluster_status.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# This file is part of Fog::Proxmox.
+
+# Fog::Proxmox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# Fog::Proxmox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with Fog::Proxmox. If not, see <http://www.gnu.org/licenses/>.
+
+module Fog
+  module Proxmox
+    class Compute
+      # Get cluster and node membership information.
+      class Real
+        def cluster_status
+          request(
+            expects: [200],
+            method: 'GET',
+            path: 'cluster/status'
+          )
+        end
+      end
+
+      # Mock cluster membership information.
+      class Mock
+        def cluster_status
+          [
+            {
+              'id' => 'node/proxmox',
+              'ip' => '192.168.56.101',
+              'name' => 'proxmox',
+              'online' => 1,
+              'type' => 'node'
+            }
+          ]
+        end
+      end
+    end
+  end
+end

--- a/spec/compute_spec.rb
+++ b/spec/compute_spec.rb
@@ -71,6 +71,19 @@ describe Fog::Proxmox::Compute do
     end
   end
 
+  it 'Gets cluster status' do
+    VCR.use_cassette('cluster_status') do
+      status = @service.cluster_status
+
+      _(status).wont_be_nil
+      _(status).wont_be_empty
+
+      node = status.find { |entry| entry['type'] == 'node' }
+      _(node).wont_be_nil
+      _(node['ip']).wont_be_nil
+    end
+  end
+
   it 'Manage storages' do
     VCR.use_cassette('storages') do
       # Get node

--- a/spec/fixtures/proxmox/compute/cluster_status.yml
+++ b/spec/fixtures/proxmox/compute/cluster_status.yml
@@ -1,0 +1,24 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://192.168.56.101:8006/api2/json/cluster/status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/2.2.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":[{"id":"node/pve","ip":"192.168.56.101","local":1,"name":"pve","nodeid":0,"online":1,"type":"node"}]}'
+    http_version:
+  recorded_at: Wed, 25 Nov 2020 13:38:38 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
- Added a new cluster_status request exposing the Proxmox /cluster/status API.
- Added a mock implementation for cluster_status.

Side note:

This PR is specifically intended to support the SSH public key authentication work in the corresponding foreman_fog_proxmox PR [SSH-PR](https://github.com/theforeman/foreman_fog_proxmox/pull/495), where the plugin needs to resolve the IP address of the Proxmox node hosting a VM in multi-node clusters.

