### PR TITLE
Fixes #136 - Declare additional container config attributes for read round-trip

### DIFF
--- a/lib/fog/proxmox/compute/models/server_config.rb
+++ b/lib/fog/proxmox/compute/models/server_config.rb
@@ -69,6 +69,12 @@ module Fog
         attribute :pool
         attribute :bwlimit
         attribute :unprivileged
+        attribute :features
+        attribute :tags
+        attribute :protection
+        attribute :timezone
+        attribute :hookscript
+        attribute :debug
         attribute :interfaces
         attribute :disks
         attribute :ciuser

--- a/spec/fog/proxmox/compute/server_config_spec.rb
+++ b/spec/fog/proxmox/compute/server_config_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Copyright 2018 Tristan Robert
+
+# This file is part of Fog::Proxmox.
+
+# Fog::Proxmox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# Fog::Proxmox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with Fog::Proxmox. If not, see <http://www.gnu.org/licenses/>.
+
+require 'spec_helper'
+require 'fog/proxmox'
+require 'fog/proxmox/compute/models/server_config'
+
+describe 'Fog::Proxmox::Compute::ServerConfig' do
+  it 'declares additional container config attributes so they round-trip on read' do
+    %i[features tags protection timezone hookscript debug].each do |attr|
+      _(Fog::Proxmox::Compute::ServerConfig.attributes).must_include attr
+    end
+  end
+
+  it 'populates the additional container attributes from a config response' do
+    config = Fog::Proxmox::Compute::ServerConfig.new(
+      vmid: 100,
+      service: Object.new,
+      features: 'nesting=1,keyctl=1',
+      tags: 'prod;db',
+      protection: 1,
+      timezone: 'Europe/Prague',
+      hookscript: 'local:snippets/hook.pl',
+      debug: 1
+    )
+    _(config.features).must_equal 'nesting=1,keyctl=1'
+    _(config.tags).must_equal 'prod;db'
+    _(config.protection).must_equal 1
+    _(config.timezone).must_equal 'Europe/Prague'
+    _(config.hookscript).must_equal 'local:snippets/hook.pl'
+    _(config.debug).must_equal 1
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #136.

`ServerConfig` does not declare several Proxmox container/guest config keys, so although they are written correctly (the create/update body is a pass-through `URI.encode_www_form`), they are dropped on read — `server.config.features` and friends return nothing, so consumers (e.g. foreman_fog_proxmox) cannot round-trip them on edit.

This declares the missing attributes so they are surfaced by `all_attributes` on read:

- `features` (LXC container features: nesting, keyctl, fuse, mount, …)
- `tags`
- `protection`
- `timezone` (LXC)
- `hookscript`
- `debug` (LXC)

There is no behavioural change to the write path — these keys were already accepted there.

## Tests

- `spec/fog/proxmox/compute/server_config_spec.rb`: asserts the new attributes are declared on `ServerConfig`.

---

_Drafted with the assistance of Claude (Cowork); reviewed by me before submitting._
