### PR TITLE
Fixes #137 - Support LXC mount-point options (ro, mountoptions, acl, quota) and bind mounts

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -52,7 +52,7 @@ Metrics/MethodLength:
 # Offense count: 2
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:
-  Max: 133
+  Max: 138
 
 # Offense count: 5
 # Configuration parameters: AllowedMethods, AllowedPatterns, IgnoredMethods.

--- a/lib/fog/proxmox/compute/models/disk.rb
+++ b/lib/fog/proxmox/compute/models/disk.rb
@@ -40,6 +40,10 @@ module Fog
         attribute :backup
         attribute :aio
         attribute :mp
+        attribute :ro
+        attribute :mountoptions
+        attribute :acl
+        attribute :quota
 
         def controller
           Fog::Proxmox::DiskHelper.extract_controller(id)
@@ -59,6 +63,10 @@ module Fog
 
         def mount_point?
           Fog::Proxmox::DiskHelper.mount_point?(id)
+        end
+
+        def bind_mount?
+          Fog::Proxmox::DiskHelper.bind_mount?(volid)
         end
 
         def controller?

--- a/lib/fog/proxmox/helpers/controller_helper.rb
+++ b/lib/fog/proxmox/helpers/controller_helper.rb
@@ -23,7 +23,7 @@ module Fog
     module ControllerHelper
       CONTROLLERS = %w[ide sata scsi virtio mp rootfs].freeze
       def self.extract(name, controller_value)
-        matches = controller_value.match(%r{,{0,1}#{name}={1}(?<name_value>[\w/.:]+)})
+        matches = controller_value.match(%r{,{0,1}#{name}={1}(?<name_value>[\w/.:;-]+)})
         matches ? matches[:name_value] : matches
       end
 

--- a/lib/fog/proxmox/helpers/disk_helper.rb
+++ b/lib/fog/proxmox/helpers/disk_helper.rb
@@ -76,9 +76,19 @@ module Fog
         name_value&.first
       end
 
+      # A bind mount point references an absolute host directory as its
+      # volume (e.g. mp0: /host/dir,mp=/container/dir) instead of a storage
+      # volume, so it has neither a storage nor a size.
+      def self.bind_mount?(volid)
+        volid.to_s.start_with?('/')
+      end
+
       # Convert API Proxmox volume/disk parameter string into volume/disk attributes hash value
       def self.extract_storage_volid_size(disk_value)
         # volid definition: <VOLUME_ID>:=<STORAGE_ID>:<storage type dependent volume name>
+        volume = disk_value.split(',').first
+        return [nil, volume, nil] if bind_mount?(volume)
+
         values_a = disk_value.scan(%r{^(([\w-]+):{0,1}([\w/.-]+))})
         no_cdrom = !disk_value.match(CDROM_REGEXP)
         creation = disk_value.split(',')[0].match(/^(([\w-]+):{1}(\d+))$/)

--- a/spec/helpers/controller_helper_spec.rb
+++ b/spec/helpers/controller_helper_spec.rb
@@ -39,8 +39,17 @@ describe Fog::Proxmox::ControllerHelper do
   let(:mp) do
     { mp0: 'local-lvm:1,mp=/opt/path' }
   end
+  let(:mp_options) do
+    { mp0: 'local-lvm:1,mp=/opt/path,mountoptions=noatime;nodev,acl=1' }
+  end
   let(:rootfs) do
     { rootfs: 'local-lvm:1' }
+  end
+  let(:mp_hyphen) do
+    { mp0: 'local-lvm:1,mp=/opt/my-app' }
+  end
+  let(:net_trunks) do
+    { net0: 'name=eth0,bridge=vmbr0,trunks=10;20;30,tag=5' }
   end
 
   describe '#extract' do
@@ -77,6 +86,21 @@ describe Fog::Proxmox::ControllerHelper do
     it 'returns cidr ip6' do
       path = Fog::Proxmox::ControllerHelper.extract('ip6', net_lxc[:net0])
       assert_equal '2001:0000:1234:0000:0000:C1C0:ABCD:0876/31', path
+    end
+
+    it 'returns multi-value mountoptions' do
+      mountoptions = Fog::Proxmox::ControllerHelper.extract('mountoptions', mp_options[:mp0])
+      assert_equal 'noatime;nodev', mountoptions
+    end
+
+    it 'returns a mount path containing a hyphen' do
+      path = Fog::Proxmox::ControllerHelper.extract('mp', mp_hyphen[:mp0])
+      assert_equal '/opt/my-app', path
+    end
+
+    it 'returns a semicolon-separated vlan trunks list' do
+      trunks = Fog::Proxmox::ControllerHelper.extract('trunks', net_trunks[:net0])
+      assert_equal '10;20;30', trunks
     end
   end
 

--- a/spec/helpers/disk_helper_spec.rb
+++ b/spec/helpers/disk_helper_spec.rb
@@ -125,6 +125,13 @@ describe Fog::Proxmox::DiskHelper do
       assert_nil size
     end
 
+    it 'returns a bind mount host path as volid with no storage or size' do
+      storage, volid, size = Fog::Proxmox::DiskHelper.extract_storage_volid_size('/host/dir,mp=/data,ro=1')
+      assert_nil storage
+      assert_equal('/host/dir', volid)
+      assert_nil size
+    end
+
     it 'returns virtio get local storage volid and size' do
       storage, volid, size = Fog::Proxmox::DiskHelper.extract_storage_volid_size(virtio[:virtio1])
       assert_equal('local', storage)
@@ -306,6 +313,20 @@ describe Fog::Proxmox::DiskHelper do
 
     it 'qemu and scsi0 returns false' do
       refute Fog::Proxmox::DiskHelper.of_type?(scsi0, 'lxc')
+    end
+  end
+
+  describe '#bind_mount?' do
+    it '/host/dir returns true' do
+      assert Fog::Proxmox::DiskHelper.bind_mount?('/host/dir')
+    end
+
+    it 'local-lvm:vm-100-disk-0 returns false' do
+      refute Fog::Proxmox::DiskHelper.bind_mount?('local-lvm:vm-100-disk-0')
+    end
+
+    it 'nil returns false' do
+      refute Fog::Proxmox::DiskHelper.bind_mount?(nil)
     end
   end
 end


### PR DESCRIPTION
## Summary

Fixes #137.

LXC mount points accept several options the `Disk` model did not declare, and bind mounts (a host directory used as the volume) were not handled at all — reading a config with a bind mount raised `NoMethodError`.

### Mount-point options

Declares `ro`, `mountoptions`, `acl` and `quota` on `Disk` (`replicate`, `shared` and `backup` were already present), so they round-trip on read and are serialised on write via the existing `DiskHelper.flatten` options path.

### Bind mounts

- `DiskHelper.bind_mount?(volid)` — a volume is a bind mount when it is an absolute host path.
- `DiskHelper.extract_storage_volid_size` now returns the host path as the volume (no storage, no size) for a bind mount instead of raising.
- `Disk#bind_mount?` predicate.

### mountoptions read fidelity

`ControllerHelper.extract` now allows `;` in option values, so multi-value options such as `mountoptions=noatime;nodev` (and NIC `trunks=2;3;4`) round-trip fully instead of being truncated at the first `;`.

## Tests

- `DiskHelper#bind_mount?` and bind-mount parsing in `extract_storage_volid_size`.
- `ControllerHelper#extract` returns multi-value `mountoptions`.

Full suite green (`rake spec`), rubocop clean. The `Metrics/ModuleLength` todo max was bumped 133 → 138 for the grown `DiskHelper`.

---

_Drafted with the assistance of Claude (Cowork); reviewed by me before submitting._
