### PR TITLE
Fixes #138 - Add HA resource management (/cluster/ha/resources)

### DIFF
--- a/lib/fog/proxmox/compute.rb
+++ b/lib/fog/proxmox/compute.rb
@@ -46,6 +46,8 @@ module Fog
       collection :tasks
       model :snapshot
       collection :snapshots
+      model :ha_resource
+      collection :ha_resources
 
       # Requests
       request_path 'fog/proxmox/compute/requests'
@@ -90,6 +92,12 @@ module Fog
       request :update_snapshot
       request :delete_snapshot
       request :rollback_snapshot
+      # CRUD HA resources
+      request :list_ha_resources
+      request :get_ha_resource
+      request :create_ha_resource
+      request :update_ha_resource
+      request :delete_ha_resource
       # Consoles
       request :create_term
       request :create_spice

--- a/lib/fog/proxmox/compute/models/ha_resource.rb
+++ b/lib/fog/proxmox/compute/models/ha_resource.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Copyright 2018 Tristan Robert
+
+# This file is part of Fog::Proxmox.
+
+# Fog::Proxmox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# Fog::Proxmox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with Fog::Proxmox. If not, see <http://www.gnu.org/licenses/>.
+
+require 'fog/proxmox/attributes'
+
+module Fog
+  module Proxmox
+    class Compute
+      # HaResource model: an entry of the cluster HA manager
+      # https://pve.proxmox.com/pve-docs/api-viewer/index.html#/cluster/ha/resources
+      class HaResource < Fog::Model
+        identity  :sid
+        attribute :type
+        attribute :state
+        attribute :group
+        attribute :max_relocate
+        attribute :max_restart
+        attribute :comment
+        attribute :digest
+
+        def initialize(new_attributes = {})
+          prepare_service_value(new_attributes)
+          Fog::Proxmox::Attributes.set_attr_and_sym('sid', attributes, new_attributes)
+          requires :sid
+          super(new_attributes)
+        end
+
+        def save
+          service.create_ha_resource(request_params)
+        end
+
+        def update
+          # sid is passed in the path; type is create-only and rejected by PVE on update
+          service.update_ha_resource({ sid: sid }, request_params.reject { |key, _value| %i[sid type].include?(key) })
+        end
+
+        def destroy
+          service.delete_ha_resource(sid: sid)
+        end
+
+        private
+
+        def request_params
+          params = {
+            sid: sid,
+            type: type,
+            group: group,
+            state: state,
+            max_relocate: max_relocate,
+            max_restart: max_restart,
+            comment: comment
+          }
+          params.reject { |_key, value| value.nil? }
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/proxmox/compute/models/ha_resources.rb
+++ b/lib/fog/proxmox/compute/models/ha_resources.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Copyright 2018 Tristan Robert
+
+# This file is part of Fog::Proxmox.
+
+# Fog::Proxmox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# Fog::Proxmox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with Fog::Proxmox. If not, see <http://www.gnu.org/licenses/>.
+
+require 'fog/proxmox/compute/models/ha_resource'
+
+module Fog
+  module Proxmox
+    class Compute
+      # class HaResources Collection of cluster HA resources
+      class HaResources < Fog::Collection
+        model Fog::Proxmox::Compute::HaResource
+
+        def all
+          load service.list_ha_resources
+        end
+
+        def get(sid)
+          all.find { |resource| resource.identity == sid }
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/proxmox/compute/requests/create_ha_resource.rb
+++ b/lib/fog/proxmox/compute/requests/create_ha_resource.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Copyright 2018 Tristan Robert
+
+# This file is part of Fog::Proxmox.
+
+# Fog::Proxmox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# Fog::Proxmox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with Fog::Proxmox. If not, see <http://www.gnu.org/licenses/>.
+
+module Fog
+  module Proxmox
+    class Compute
+      # class Real create_ha_resource request
+      class Real
+        def create_ha_resource(body_params)
+          request(
+            expects: [200],
+            method: 'POST',
+            path: 'cluster/ha/resources',
+            body: URI.encode_www_form(body_params)
+          )
+        end
+      end
+
+      # class Mock create_ha_resource request
+      class Mock
+        def create_ha_resource(_body_params); end
+      end
+    end
+  end
+end

--- a/lib/fog/proxmox/compute/requests/delete_ha_resource.rb
+++ b/lib/fog/proxmox/compute/requests/delete_ha_resource.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Copyright 2018 Tristan Robert
+
+# This file is part of Fog::Proxmox.
+
+# Fog::Proxmox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# Fog::Proxmox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with Fog::Proxmox. If not, see <http://www.gnu.org/licenses/>.
+
+module Fog
+  module Proxmox
+    class Compute
+      # class Real delete_ha_resource request
+      class Real
+        def delete_ha_resource(path_params)
+          sid = path_params[:sid]
+          request(
+            expects: [200],
+            method: 'DELETE',
+            path: "cluster/ha/resources/#{sid}"
+          )
+        end
+      end
+
+      # class Mock delete_ha_resource request
+      class Mock
+        def delete_ha_resource(_path_params); end
+      end
+    end
+  end
+end

--- a/lib/fog/proxmox/compute/requests/get_ha_resource.rb
+++ b/lib/fog/proxmox/compute/requests/get_ha_resource.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Copyright 2018 Tristan Robert
+
+# This file is part of Fog::Proxmox.
+
+# Fog::Proxmox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# Fog::Proxmox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with Fog::Proxmox. If not, see <http://www.gnu.org/licenses/>.
+
+module Fog
+  module Proxmox
+    class Compute
+      # class Real get_ha_resource request
+      class Real
+        def get_ha_resource(path_params)
+          sid = path_params[:sid]
+          request(
+            expects: [200],
+            method: 'GET',
+            path: "cluster/ha/resources/#{sid}"
+          )
+        end
+      end
+
+      # class Mock get_ha_resource request
+      class Mock
+        def get_ha_resource(_path_params)
+          {
+            'sid' => 'vm:100',
+            'type' => 'vm',
+            'state' => 'started',
+            'group' => 'prod',
+            'max_relocate' => 1,
+            'max_restart' => 1,
+            'comment' => 'web server',
+            'digest' => 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/proxmox/compute/requests/list_ha_resources.rb
+++ b/lib/fog/proxmox/compute/requests/list_ha_resources.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# Copyright 2018 Tristan Robert
+
+# This file is part of Fog::Proxmox.
+
+# Fog::Proxmox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# Fog::Proxmox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with Fog::Proxmox. If not, see <http://www.gnu.org/licenses/>.
+
+module Fog
+  module Proxmox
+    class Compute
+      # class Real list_ha_resources request
+      class Real
+        def list_ha_resources
+          request(
+            expects: [200],
+            method: 'GET',
+            path: 'cluster/ha/resources'
+          )
+        end
+      end
+
+      # class Mock list_ha_resources request
+      class Mock
+        def list_ha_resources
+          [
+            {
+              'sid' => 'vm:100',
+              'type' => 'vm',
+              'state' => 'started',
+              'group' => 'prod',
+              'max_relocate' => 1,
+              'max_restart' => 1,
+              'comment' => 'web server',
+              'digest' => 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+            }
+          ]
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/proxmox/compute/requests/update_ha_resource.rb
+++ b/lib/fog/proxmox/compute/requests/update_ha_resource.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Copyright 2018 Tristan Robert
+
+# This file is part of Fog::Proxmox.
+
+# Fog::Proxmox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# Fog::Proxmox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with Fog::Proxmox. If not, see <http://www.gnu.org/licenses/>.
+
+module Fog
+  module Proxmox
+    class Compute
+      # class Real update_ha_resource request
+      class Real
+        def update_ha_resource(path_params, body_params)
+          sid = path_params[:sid]
+          request(
+            expects: [200],
+            method: 'PUT',
+            path: "cluster/ha/resources/#{sid}",
+            body: URI.encode_www_form(body_params)
+          )
+        end
+      end
+
+      # class Mock update_ha_resource request
+      class Mock
+        def update_ha_resource(_path_params, _body_params); end
+      end
+    end
+  end
+end

--- a/spec/fog/proxmox/compute/ha_resource_spec.rb
+++ b/spec/fog/proxmox/compute/ha_resource_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+# Copyright 2018 Tristan Robert
+
+# This file is part of Fog::Proxmox.
+
+# Fog::Proxmox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# Fog::Proxmox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with Fog::Proxmox. If not, see <http://www.gnu.org/licenses/>.
+
+require 'spec_helper'
+require 'fog/proxmox/compute/models/ha_resource'
+
+describe 'Fog::Proxmox::Compute::HaResource' do
+  # A HA resource can only be built with a service (fog requires one). This
+  # minimal stub records the request it is handed so we can assert on it.
+  def build(method, attrs = {})
+    calls = []
+    service = Object.new
+    service.define_singleton_method(method) do |*args|
+      calls << args
+      nil
+    end
+    resource = Fog::Proxmox::Compute::HaResource.new(
+      { sid: 'ct:100', type: 'ct', service: service }.merge(attrs)
+    )
+    [resource, calls]
+  end
+
+  it 'declares the HA resource attributes' do
+    %i[sid type state group max_relocate max_restart comment digest].each do |attr|
+      _(Fog::Proxmox::Compute::HaResource.attributes).must_include attr
+    end
+  end
+
+  it 'drops nil params from the request body' do
+    resource, = build(:create_ha_resource, state: 'started')
+    params = resource.send(:request_params)
+    _(params[:sid]).must_equal 'ct:100'
+    _(params[:type]).must_equal 'ct'
+    _(params[:state]).must_equal 'started'
+    _(params.key?(:group)).must_equal false
+    _(params.key?(:comment)).must_equal false
+  end
+
+  it 'save posts sid and type to create_ha_resource' do
+    resource, calls = build(:create_ha_resource, state: 'started', group: 'prod')
+    resource.save
+    body = calls.first.first
+    _(body[:sid]).must_equal 'ct:100'
+    _(body[:type]).must_equal 'ct'
+    _(body[:state]).must_equal 'started'
+    _(body[:group]).must_equal 'prod'
+  end
+
+  it 'update omits the create-only sid and type from the request body' do
+    resource, calls = build(:update_ha_resource, state: 'stopped', group: 'prod')
+    resource.update
+    path_params, body = calls.first
+    _(path_params).must_equal(sid: 'ct:100')
+    _(body.key?(:sid)).must_equal false
+    _(body.key?(:type)).must_equal false
+    _(body[:state]).must_equal 'stopped'
+    _(body[:group]).must_equal 'prod'
+  end
+
+  it 'destroy deletes by sid' do
+    resource, calls = build(:delete_ha_resource)
+    resource.destroy
+    _(calls.first.first).must_equal(sid: 'ct:100')
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #138.

Adds a CRUD subsystem for the cluster HA manager (`/cluster/ha/resources`), so callers (e.g. foreman_fog_proxmox) can place guests under Proxmox HA.

- `HaResource` model — `sid` (identity, e.g. `vm:100`), `type`, `state`, `group`, `max_relocate`, `max_restart`, `comment`, `digest`; with `save` / `update` / `destroy`.
- `HaResources` collection — `all`, `get(sid)`.
- Requests: `list_ha_resources`, `get_ha_resource`, `create_ha_resource`, `update_ha_resource`, `delete_ha_resource`, each with a `Mock` implementation.
- Registered on the compute service.

## Tests

- `spec/fog/proxmox/compute/ha_resource_spec.rb`: asserts the model declares the HA attributes.

Full suite green (`rake spec`), rubocop clean.

---

_Drafted with the assistance of Claude (Cowork); reviewed by me before submitting._
