### PR TITLE
fix: RuboCop extra spacing offenses

### DIFF
--- a/fog-proxmox.gemspec
+++ b/fog-proxmox.gemspec
@@ -52,7 +52,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'vcr', '~> 4.0'
   spec.add_development_dependency 'webmock', '~> 3.5'
 
-  spec.add_dependency 'fog-core',  '>= 2.1'
-  spec.add_dependency 'fog-json',  '>= 1.2'
+  spec.add_dependency 'fog-core', '>= 2.1'
+  spec.add_dependency 'fog-json', '>= 1.2'
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/spec/proxmox_vcr.rb
+++ b/spec/proxmox_vcr.rb
@@ -45,9 +45,9 @@ class ProxmoxVCR
 
     if use_recorded
       Fog.interval = 0
-      @url  = 'https://192.168.56.101:8006/api2/json'
+      @url = 'https://192.168.56.101:8006/api2/json'
     else
-      @url  = ENV['PROXMOX_URL']
+      @url = ENV['PROXMOX_URL']
     end
 
     VCR.configure do |config|


### PR DESCRIPTION
- Fixed Layout/ExtraSpacing offenses reported by RuboCop on Ruby 3.5 and newer to keep the lint pipeline passing across supported Ruby versions.